### PR TITLE
remove require pry statement

### DIFF
--- a/lib/aemo.rb
+++ b/lib/aemo.rb
@@ -1,7 +1,6 @@
 require 'active_support/all'
 require 'httparty'
 require 'csv'
-require 'pry'
 
 require 'aemo/market.rb'
 require 'aemo/market/interval.rb'


### PR DESCRIPTION
Requiring pry breaks this gem since it's not a dependency - pretty sure it's not needed here.