### PR TITLE
Nokogiri vulnerability CVE-2017-15412

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # AEMO Gem Changelog
 
+## 0.1.45
+
+* [Nokogiri vulnerability](https://rubysec.com/advisories/nokogiri-CVE-2017-15412) update
+
 ## 0.1.44
 
 * [YARD vulnerability](https://rubysec.com/advisories/yard-CVE-2017-17042) update

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 PATH
   remote: .
   specs:
-    aemo (0.1.43)
+    aemo (0.1.45)
       activesupport (>= 4.2.6, < 5.2)
       httparty (~> 0.15, >= 0.15.6)
       json (>= 1.7.5)
       multi_xml (~> 0.6, >= 0.5.0)
-      nokogiri (~> 1.8, >= 1.8.1)
+      nokogiri (~> 1.8, >= 1.8.2)
 
 GEM
   remote: https://rubygems.org/
@@ -61,9 +61,9 @@ GEM
     hashdiff (0.3.7)
     hashie (3.5.6)
     highline (1.7.8)
-    httparty (0.15.6)
+    httparty (0.15.7)
       multi_xml (>= 0.5.2)
-    i18n (0.9.1)
+    i18n (0.9.3)
       concurrent-ruby (~> 1.0)
     jeweler (2.3.7)
       builder
@@ -86,12 +86,12 @@ GEM
     method_source (0.9.0)
     mime-types (2.99.3)
     mini_portile2 (2.3.0)
-    minitest (5.11.0)
+    minitest (5.11.3)
     multi_json (1.12.2)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
     nenv (0.3.0)
-    nokogiri (1.8.1)
+    nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     notiffany (0.1.1)
       nenv (~> 0.1)
@@ -154,7 +154,7 @@ GEM
     thread_safe (0.3.6)
     timecop (0.9.1)
     tins (1.15.0)
-    tzinfo (1.2.4)
+    tzinfo (1.2.5)
       thread_safe (~> 0.1)
     unicode-display_width (1.3.0)
     webmock (3.1.0)

--- a/aemo.gemspec
+++ b/aemo.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   # Production Dependencies
   s.add_dependency 'json',      '>= 1.7.5'
-  s.add_dependency 'nokogiri',  '~> 1.8', '>= 1.8.1'
+  s.add_dependency 'nokogiri',  '~> 1.8', '>= 1.8.2'
   s.add_dependency 'multi_xml', '~> 0.6',   '>= 0.5.0'
   s.add_dependency 'httparty',  '~> 0.15',  '>= 0.15.6'
   s.add_dependency 'activesupport', '>= 4.2.6', '< 5.2'

--- a/lib/aemo/version.rb
+++ b/lib/aemo/version.rb
@@ -24,7 +24,7 @@
 # @author Joel Courtney <euphemize@gmail.com>
 module AEMO
   # aemo version
-  VERSION = '0.1.44'
+  VERSION = '0.1.45'
 
   # aemo version split amongst different revisions
   MAJOR_VERSION, MINOR_VERSION, REVISION = VERSION.split('.').map(&:to_i)


### PR DESCRIPTION
## v0.1.45

* [Nokogiri vulnerability](https://rubysec.com/advisories/nokogiri-CVE-2017-15412) update
